### PR TITLE
Fix type error in port variable

### DIFF
--- a/slime/start-swank.lisp
+++ b/slime/start-swank.lisp
@@ -32,7 +32,7 @@
     #+LISPWORKS (lispworks:environment-variable name)
     default))
 
-(swank:create-server :port (parse-integer (my-getenv "SWANK_PORT" 4005))
+(swank:create-server :port (parse-integer (my-getenv "SWANK_PORT" "4005"))
                      ;; if non-nil the connection won't be closed
                      ;; after connecting
                      :dont-close t)


### PR DESCRIPTION
Fixes the error...
debugger invoked on a TYPE-ERROR in thread
  The value 4005 is not of type STRING.

Environment...
Linux 3.2.0-4-amd64 #1 SMP Debian 3.2.46-1 x86_64 GNU/Linux
VIM - Vi IMproved 7.3 (debian package)
SBCL 1.0.57.0.debian
