### PR TITLE
Fix #4: Scheme builtin swank not launching.

### DIFF
--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -95,7 +95,8 @@ function! SlimvSwankCommand()
                     let path2as = globpath( &runtimepath, 'ftplugin/**/iterm.applescript')
                     return '!' . path2as . ' ' . cmd
                 else
-                    return '!osascript -e "tell application \"Terminal\" to do script \"' . cmd . '\""'
+                    " doubles quotes within 'cmd' need to become '\\\"'
+                    return '!osascript -e "tell application \"Terminal\" to do script \"' . escape(escape(cmd, '"'), '\"') . '\""'
                 endif 
         elseif $STY != ''
             " GNU screen under Linux


### PR DESCRIPTION
Problem: 'scheme_builtin_swank' set to 1 but swank server not launching.
Solution: Properly escape autogenerated swank start command.
