### PR TITLE
[Bugfix] 2 keymaps assumed g:paredit_leader is identical to ','.

### DIFF
--- a/plugin/paredit.vim
+++ b/plugin/paredit.vim
@@ -147,8 +147,8 @@ function! PareditInitBuffer()
         call RepeatableNNoRemap(g:paredit_leader . 'w"', ':<C-U>call PareditWrap('."'".'"'."','".'"'."')")
         execute 'vnoremap <buffer> <silent> ' . g:paredit_leader.'w"  :<C-U>call PareditWrapSelection('."'".'"'."','".'"'."')<CR>"
         " Spliec s-expression killing backward/forward
-        execute 'nmap     <buffer> <silent> ' . g:paredit_leader.'<Up>    d[(,S'
-        execute 'nmap     <buffer> <silent> ' . g:paredit_leader.'<Down>  d])%,S'
+        execute 'nmap     <buffer> <silent> ' . g:paredit_leader.'<Up>    d[(:<C-U>call PareditSplice()<CR>'
+        execute 'nmap     <buffer> <silent> ' . g:paredit_leader.'<Down>  d])%:<C-U>call PareditSplice()<CR>'
         call RepeatableNNoRemap(g:paredit_leader . 'I', ':<C-U>call PareditRaise()')
         if &ft =~ '.*\(clojure\|scheme\|racket\).*'
             inoremap <buffer> <expr>   [            PareditInsertOpening('[',']')


### PR DESCRIPTION
I guess that the `,` in the original code are used as the leader for paredit, but it can be different than `,`.
A simple solution, replacing `,S` by `g:paredit_leader.'S'`, is not sufficient because `g:paredit_leader.'S'` can behave as vim's initial `S` if we set `g:paredit_shortmaps` to a value other than 0. ~~Even if the value of `g:paredit_shortmaps` is 0, `g:paredit_leader.'S'` is mapped through `nnoremap` and therefore `S` in the original code behaves as vim's initial `S`.~~

This pull request proposes a fix for this problem by calling PareditSplice function directly.
### Postscript

The struck out sentence is wrong. The original code works as it is intended if `g:paredit_leader` is `,` and `g:paredit_shormaps` is `0`.
