### PR TITLE
Added Slimv-specific code back to swank-mit-scheme.scm

### DIFF
--- a/slime/contrib/swank-mit-scheme.scm
+++ b/slime/contrib/swank-mit-scheme.scm
@@ -61,6 +61,11 @@
 
 ;;; package: (swank)
 
+;; Modified for Slimv:
+;; - load options
+(load-option 'format)
+(load-option 'sos)
+
 (if (< (car (get-subsystem-version "Release"))
        '9)
     (error "This file requires MIT Scheme Release 9"))
@@ -866,5 +871,11 @@
   ;;(apply format log-port fstring args)
   #f
   )
+
+;; Modified for Slimv:
+;; - restart swank server in a loop
+(let loop ()
+ (swank 4005)
+ (loop))
 
 ;;; swank-mit-scheme.scm ends here


### PR DESCRIPTION
Added Slimv-specific code (loading options, restarting swank server) back to swank-mit-scheme.scm.  This fixed an "unbound variable: o" error on load of swank-mit-scheme.scm in the MIT-Scheme 9.2 REPL (using OSX 10.9.5) that was blocking loading of the server.  Vim is now able to start and connect to an MIT-Scheme swank server.
