### PR TITLE
[Bugfix] Null character should not be inserted from Python side.

### DIFF
--- a/ftplugin/swank.py
+++ b/ftplugin/swank.py
@@ -762,7 +762,7 @@ def swank_listen():
                                     retval = retval + unquote(params)
                                     if action:
                                         action.result = retval
-                                vim.command("let s:swank_ok_result='%s'" % retval.replace("'", "''"))
+                                vim.command("let s:swank_ok_result='%s'" % retval.replace("'", "''").replace("\0", "^@"))
                                 if element == 'nil' or (action and action.name in to_prompt):
                                     # No more output from REPL, write new prompt
                                     retval = retval + new_line(retval) + get_prompt()


### PR DESCRIPTION
The swank_listen python function substitutes the evaluation result to s:swank_ok_result vim variable. Since the null character is not allowed to be passed from Python side, vim raises an error when the result includes null characters.

When we evaluate following code, for example, the result string is composed of a single null character and vim will raise an error.

    (make-sequence 'string 1)

This request propose to replace null characters appear in the result by "^@" in order to avoid the bug explained.
The replacing string, "^@", can be altered by other string. I just chose this string to make the appearance similar.