### PR TITLE
Update README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -132,6 +132,17 @@ For Clojure use the g:slimv_swank_clojure option, e.g.:
     let g:slimv_swank_clojure = '! xterm -e lein swank &' 
 
 
+- For pure text-based console without XTerm
+
+If you only have `SSH` and can not use `XTerm`, you can use `tmux` instead of it.
+
+Linux example without XTerm:
+    let g:slimv_swank_cmd = '! tmux new-window -d -n REPL-SBCL "sbcl --load ~/.vim/bundle/slimv/slime/start-swank.lisp"'
+    
+Mac OS X example:
+    let g:slimv_swank_cmd = '!osascript -e "! tmux new-window -d -n REPL-SBCL "sbcl --load ~/.vim/bundle/slimv/slime/start-swank.lisp"'
+
+
 See the included documentation for more complete installation and customization instructions.
 
 


### PR DESCRIPTION
Sometimes, people have no XWindows when they connect a host with SSH, so they can not start Xterm.
Another words, in a pure text-based console without GUI, people can not use slimv with the default configure. 
So it is better to use tmux instead of Xterm  as the default configuration.
