### PR TITLE
Fix for #37: Unable to disable default keybindings 

### DIFF
--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -3375,6 +3375,9 @@ function! s:MenuMap( name, shortcut1, shortcut2, command )
     elseif g:slimv_keybindings == 2
         " Easy to remember (two-key) keybinding set
         let shortcut = a:shortcut2
+    else
+        " No bindings
+        let shortcut = ''
     endif
 
     if shortcut != ''


### PR DESCRIPTION
Sets `shortcut` to '' to prevent errors when g:slimv_keybindings is not `1` or `2`.