### PR TITLE
Bugfix: call winrestview() after SlimvCompileDefun

### DIFF
--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -2985,6 +2985,7 @@ function! SlimvCompileDefun()
         let s:swank_form = SlimvGetSelection()
         call SlimvCommandUsePackage( 'python swank_compile_string("s:swank_form")' )
     endif
+    call winrestview( oldpos )
 endfunction
 
 " Compile and load whole file


### PR DESCRIPTION
added missing 'call winrestview( oldpos )' at the end of function
'SlimvCompileDefun()'. This will prevent the cursor to move to the
opening paren of the compiled defun, if the call to 'SlimvCompileDefun'
was successful.