### PR TITLE
[Bugfix] Swank boot commands in the case of screen is fixed.

### DIFF
--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -100,7 +100,7 @@ function! SlimvSwankCommand()
                 endif 
         elseif $STY != ''
             " GNU screen under Linux
-            return '! screen -X eval "title swank" "screen ' . cmd . '" "select swank"'
+            return "! screen -X eval 'title swank' 'screen " . cmd . "' 'select swank'"
         elseif $TMUX != ''
             " tmux under Linux
             return "! tmux new-window -d -n swank '" . cmd . "'"


### PR DESCRIPTION
`SlimvSwankLoader` function quotes both of `g:slimv_lisp` and the argument of --load argument (or -l or -i, etc), but it did not work as it is expected in the case of screen. This commit fixes `SlimvSwankCommand` and ensures to properly quote them by adopting single quotes to quote each screen command.

If the path of `slime` directory included a whitespace, then what `SlimvSwankLoader` returned was something like:

    "/usr/bin/sbcl" --load "/home/foo/personal swankdir/slime/start-swank.lisp"

Here, it is assumed that `let g:slimv_impl = 'sbcl'` and `let g:slimv_lisp='/usr/bin/sbcl'` are written in .vimrc. 
Finally, `SlimvSwankCommand` function returns following command string if vim is run on screen.

    ! screen -X eval "title swank" "screen "/usr/bin/sbcl" --load "/home/foo/personal swankdir/slime/start-swank.lisp"" "select swank"

For clarity, the commands executed by `screen -X eval` is as follows.

1. title swank
2. screen /usr/bin/sbcl --load /home/foo/personal
3. swankdir/slime/start-swank.lisp
4. select swank

But the commands we truly want should be next one.

1. title swank
2. screen "/usr/bin/sbcl" --load "/home/foo/personal swankdir/slime/start-swank.lisp"
3. select swank

This commit fixes the string returned by `SlimvSwankLoader` in this situation. The fixed return value is as follows.

    ! screen -X eval 'title swank' 'screen "/usr/bin/sbcl" --load "/home/foo/personal swankdir/slime/start-swank.lisp"' 'select swank'