### PR TITLE
Ignore Vim generated tags file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
Rationale: When using git submodules + pathogen to maintain your vim plugin collection, git often complains about the sub projects being dirty. This is most often because of the generated `doc/tags` file. Ignoring it should solve the issue.

![Dirty SubProjects](http://i.imgur.com/lKUjXUU.jpg)