### PR TITLE
Modify Applescript for modern version iTerm.

### DIFF
--- a/ftplugin/iterm.applescript
+++ b/ftplugin/iterm.applescript
@@ -10,13 +10,54 @@ to joinList(aList, delimiter)
     return retVal
 end joinList
 
+-- theSplit from iTerm version check example @ https://goo.gl/dSbQYU
+on theSplit(theString, theDelimiter)
+    set oldDelimiters to AppleScript's text item delimiters
+    set AppleScript's text item delimiters to theDelimiter
+    set theArray to every text item of theString
+    set AppleScript's text item delimiters to oldDelimiters
+    return theArray
+end theSplit
+
+-- IsModernVersion from iTerm version check example @ https://goo.gl/dSbQYU
+on IsModernVersion(version)
+    set myArray to my theSplit(version, ".")
+    set major to item 1 of myArray
+    set minor to item 2 of myArray
+    set veryMinor to item 3 of myArray
+
+    if major < 2 then
+        return false
+    end if
+    if major > 2 then
+        return true
+    end if
+    if minor < 9 then
+        return false
+    end if
+    if minor > 9 then
+        return true
+    end if
+    if veryMinor < 20140903 then
+        return false
+    end if
+    return true
+end IsModernVersion
+
 on run arg
     set thecommand to joinList(arg, " ")
     tell application "iTerm"
         activate
-        set myterm to (make new terminal)
+        if my IsModernVersion(version) then
+            set myterm to (create window with default profile)
+            set mysession to current session of myterm
+        else
+            set myterm to (make new teminal)
+            tell myterm
+                set mysession to (launch session "Default")
+            end tell
+        end if
         tell myterm
-            set mysession to (launch session "Default")
             tell mysession
                 write text thecommand
             end tell


### PR DESCRIPTION
For newer version iTerm2, I got error in Applescript that says "slimv/ftplugin/iterm.applescript:530:538: execution error: execution error: terminal variable is not defined.  (-2753)"
According to official example(https://www.iterm2.com/documentation-scripting.html), I added switching code to adopt new Applescript syntax.