### PR TITLE
On macOS, run Swank in screen/tmux, if detected

### DIFF
--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -98,6 +98,12 @@ function! SlimvSwankCommand()
     if cmd != ''
         if g:slimv_windows || g:slimv_cygwin
             return '!start /MIN ' . cmd
+        elseif $STY != ''
+            " GNU screen under Linux or macOS
+            return "! screen -X eval 'title swank' 'screen " . cmd . "' 'select swank'"
+        elseif $TMUX != ''
+            " tmux under Linux or macOS
+            return "! tmux new-window -d -n swank '" . cmd . "'"
         elseif g:slimv_osx
             let result = system('osascript -e "exists application \"iterm\""')
                 if result[:-2] == 'true'
@@ -107,12 +113,6 @@ function! SlimvSwankCommand()
                     " doubles quotes within 'cmd' need to become '\\\"'
                     return '!osascript -e "tell application \"Terminal\" to do script \"' . escape(escape(cmd, '"'), '\"') . '\""'
                 endif 
-        elseif $STY != ''
-            " GNU screen under Linux
-            return "! screen -X eval 'title swank' 'screen " . cmd . "' 'select swank'"
-        elseif $TMUX != ''
-            " tmux under Linux
-            return "! tmux new-window -d -n swank '" . cmd . "'"
         elseif $DISPLAY == ''
             " No X, no terminal multiplexer. Cannot run swank server.
             call SlimvErrorWait( 'No X server. Run Vim from screen/tmux or start SWANK server manually.' )


### PR DESCRIPTION
Prior to this change, Slimv starts Swank in a new xterm or Terminal
window on macOS by default even if Vim or MacVim is launched from screen
or tmux. The precise default behavior on macOS is described below:

  - If has('macunix') = 0, then Slimv runs Swank in xterm, if available.
  - If has('macunix') = 1, then Slimv runs Swank in Terminal.

This default behavior is inconsistent with the default behavior of Slimv
on Linux desktop. On Linux desktop, if we launch Vim or GVim from screen
or tmux, then Slimv starts Swank in a new screen or tmux window,
respectively, by default. Only when Vim or GVim is launched neither from
screen nor from tmux, Slimv starts Swank in a new xterm window. The same
default behavior should be followed on macOS too for the sake of
consistency.

With this change, on macOS, if we launch Vim or MacVim from screen or
tmux, then Slimv starts Swank in a new screen or tmux window,
respectively, by default. Only when Vim or MacVim is launched neither
from screen nor from tmux, Slimv starts Swank in a new Terminal window.
This default behavior is now consistent with the default behavior of
Slimv on Linux desktop.