### PR TITLE
Use time.process_time() instead of time.clock() with python 3.3 or later

### DIFF
--- a/ftplugin/swank.py
+++ b/ftplugin/swank.py
@@ -63,9 +63,9 @@ def logprint(text):
 
 def logtime(text):
     if sys.version_info >= (3, 3):
-        logprint(text + ' ' + str(time.process_time())
+        logprint(text + ' ' + str(time.perf_counter()))
     else:
-        logprint(text + ' ' + str(time.clock())
+        logprint(text + ' ' + str(time.clock()))
 
 ###############################################################################
 # Simple Lisp s-expression parser

--- a/ftplugin/swank.py
+++ b/ftplugin/swank.py
@@ -62,7 +62,10 @@ def logprint(text):
         f.close()
 
 def logtime(text):
-    logprint(text + ' ' + str(time.clock()))
+    if sys.version_info >= (3, 3):
+        logprint(text + ' ' + str(time.process_time())
+    else:
+        logprint(text + ' ' + str(time.clock())
 
 ###############################################################################
 # Simple Lisp s-expression parser


### PR DESCRIPTION
In the Python 3.7 environment, I received a warning of the deprecated function.
By adding an if statement, it was fixed with Python 2.7 compatibility.