### PR TITLE
Make Swank load command for ECL with --load option

### DIFF
--- a/ftplugin/lisp/slimv-lisp.vim
+++ b/ftplugin/lisp/slimv-lisp.vim
@@ -136,7 +136,7 @@ function! SlimvSwankLoader()
     endif
 
     " Build proper SWANK loader command for the Lisp implementation used
-    if g:slimv_impl == 'sbcl'
+    if g:slimv_impl == 'sbcl' || g:slimv_impl == 'ecl'
         return '"' . g:slimv_lisp . '" --load "' . swanks[0] . '"'
     elseif g:slimv_impl == 'clisp'
         return '"' . g:slimv_lisp . '" -i "' . swanks[0] . '"'


### PR DESCRIPTION
Prior to this change, `SlimvSwankLoader()` builds the following Swank
loader command for Embeddable Common-Lisp (ECL):

    "ecl" -l "/home/susam/.vim/bundle/slimv/slime/start-swank.lisp"

The above command fails with the following error:

    Unknown command line option -l.

As a result, when `,c` is pressed in normal mode, Slimv fails to load
Swank server. The correct option is `--load` instead. With this change,
the following Swank loader command is built:

    "ecl" --load "/home/susam/.vim/bundle/slimv/slime/start-swank.lisp"

With this loader command, when `,c` is pressed in normal mode, Slimv is
able to load Swank server successfully.