### PR TITLE
Set classpath delimiter as per OS to run Clojure

### DIFF
--- a/ftplugin/clojure/slimv-clojure.vim
+++ b/ftplugin/clojure/slimv-clojure.vim
@@ -32,16 +32,17 @@ endfunction
 " all clojure*.jar files found to the classpath
 function! s:BuildStartCmd( lisps )
     let cp = s:TransformFilename( a:lisps[0] )
+    let cp_delim = g:slimv_windows ? ';' : ':'
     let i = 1
     while i < len( a:lisps )
-        let cp = cp . ';' . s:TransformFilename( a:lisps[i] )
+        let cp = cp . cp_delim . s:TransformFilename( a:lisps[i] )
         let i = i + 1
     endwhile
 
     " Try to find swank-clojure and add it to classpath
     let swanks = split( globpath( &runtimepath, 'swank-clojure'), '\n' )
     if len( swanks ) > 0
-        let cp = cp . ';' . s:TransformFilename( swanks[0] )
+        let cp = cp . cp_delim . s:TransformFilename( swanks[0] )
     endif
     return ['java -cp ' . cp . ' clojure.main', 'clojure']
 endfunction


### PR DESCRIPTION
Prior to this change, even if Clojure is available at one of the
auto-detected paths on Linux or Unix, e.g., `~/clojure/clojure.jar`, the
normal mode command <kbd>,</kbd><kbd>c</kbd> fails to start Swank server with Clojure. This
issue occurs because semicolon (`;`) is used as the delimiter in the
classpath value for `java -cp` option. Here is an example classpath
value that is used prior to this change:

    /home/x/clojure/clojure.jar;/home/x/.vim/bundle/slimv/swank-clojure

Semicolon (`;`) is the right delimiter for Java running on Windows but
it should be colon (`:`) on a Linux or Unix system. This change ensures
that the correct delimiter is chosen as per the current operating
system.