### PR TITLE
Set PATH delimiter as per OS to search for Clojure

### DIFF
--- a/ftplugin/clojure/slimv-clojure.vim
+++ b/ftplugin/clojure/slimv-clojure.vim
@@ -78,7 +78,8 @@ function! SlimvAutodetect( preferred )
     endif
 
     " Try to find Clojure in the PATH
-    let path = substitute( $PATH, ';', ',', 'g' )
+    let path_delim = g:slimv_windows ? ';' : ':'
+    let path = substitute( $PATH, path_delim, ',', 'g' )
     let lisps = split( globpath( path, 'clojure*.jar' ), '\n' )
     if len( lisps ) > 0
         return s:BuildStartCmd( lisps )


### PR DESCRIPTION
Prior to this change, on Linux or Unix, even if Clojure is available in
one of the paths mentioned in the PATH environment variable, the normal
mode command <kbd>,</kbd><kbd>c</kbd> fails to start Swank server with Clojure. This issue
occurs because semicolon (`;`) is assumed to be the path delimiter in
the PATH value, so when PATH is, say, `/usr/bin:/usr/local/bin` and
`clojure.jar` is available in `/usr/local/bin`, the search for Clojure
fails because Slimv tries to search for Clojure in a single directory
named `/usr/bin:/usr/local/bin`. Instead, it should search for Clojure
in two directories named `/usr/bin` and `/usr/local/bin`.

This change ensures that on Linux or Unix, colon (`:`) is interpreted as
the path delimiter in the PATH value. On Windows, semicolon (`;`) is
used as the path delimiter.