### PR TITLE
Remove note on 'lisp' filetype in lisp_rainbow doc

### DIFF
--- a/doc/slimv.txt
+++ b/doc/slimv.txt
@@ -1363,9 +1363,7 @@ with parentheses. This is a very important topic for a Lisp programmer.
     99[(v%                  Select top level form.
 
     g:lisp_rainbow          Colorize differing levels of parenthesization with
-                            different highlighting. Currently works only for
-                            the 'lisp' filetype, hopefully it will be added
-                            soon to the Clojure plugins as well.
+                            different highlighting.
 
 
 4. Completion


### PR DESCRIPTION
Slimv has `g:lisp_rainbow` support for Clojure and Scheme since Slimv
versions 0.5.4 and 0.8.2, respectively. Therefore, the sentence
regarding `g:lisp_rainbow` working only for the `lisp` filetype is no
longer accurate. This change removes that sentence.