### PR TITLE
keymap should not affect SlimvShortEcho's behavior

### DIFF
--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -402,7 +402,7 @@ endfunction
 function! SlimvShortEcho( msg )
     let saved=&shortmess
     set shortmess+=T
-    exe "normal :echomsg a:msg\n" 
+    exe "normal! :echomsg a:msg\n" 
     let &shortmess=saved
 endfunction
 


### PR DESCRIPTION
When `:` is mapped to something (e.g. swapping `;` and `:`), it did not work properly.
This should fix it.