### PR TITLE
Add g:slimv_fasl_directory controlling written location of FASL files

### DIFF
--- a/doc/slimv.txt
+++ b/doc/slimv.txt
@@ -166,6 +166,9 @@ For the Swank options plese visit |swank-configuration|.
 |g:slimv_echolines|          Echo only this number of lines from the form
                              being evaluated.
 
+|g:slimv_fasl_directory|     Specify the directory for compiled FASL files to
+                             be written to.
+
 |g:slimv_impl|               The Lisp implementation. Defaults to 'clisp'.
 
 |g:slimv_indent_disable|     Disable slimv indenting, fallback to vim's
@@ -417,6 +420,18 @@ Slimv uses a dedicated tags file for Find-Definitions. By default this is a
 temporary file but the filename can be overridden via this option. If this
 variable is set to the empty string ('') then the whole Find-Definitions
 function is disabled.
+
+
+                                                       *g:slimv_fasl_directory*
+
+Specify a directory path that will be passed to the function
+swank:compile-file-for-emacs controlling where the compiled FASL file is
+written to and loaded from when using the Compile File or the Compile and Load
+File commands.
+Example:
+    let g:slimv_fasl_directory = '/tmp/'
+If this is set then .fasl files will be placed in /tmp/ instead of the default
+location next to the Lisp source file.
 
                                                           *g:slimv_keybindings*
 Defines the keybinding set used by Slimv.

--- a/doc/slimv.txt
+++ b/doc/slimv.txt
@@ -133,10 +133,10 @@ For the Swank options plese visit |swank-configuration|.
 |g:slimv_balloon|            Specifies if tooltips are on.
 
 |g:slimv_browser_cmd|        If nonempty, this shell command is used to
-                             open the Common Lisp Hyperspec. 
+                             open the Common Lisp Hyperspec.
 
-|g:slimv_browser_cmd_ex|     If nonempty, this Ex command is used to 
-                             open the Common Lisp Hyperspec. 
+|g:slimv_browser_cmd_ex|     If nonempty, this Ex command is used to
+                             open the Common Lisp Hyperspec.
 
 |g:slimv_browser_cmd_suffix| Optional suffix for |g:slimv_browser_cmd|
 
@@ -228,7 +228,7 @@ For the Swank options plese visit |swank-configuration|.
 
 |g:slimv_swank_scheme|       Command used to start the Scheme SWANK server.
 
-|g:slimv_tags_file|          Name of tags file used by Slimv. 
+|g:slimv_tags_file|          Name of tags file used by Slimv.
 
 |g:slimv_threads_name|       Name of the Threads buffer.
 
@@ -668,7 +668,7 @@ Example:
     let g:slimv_clhs_user_db = [
         \["my-cool-function", "mycoolfunc.htm"],
         \["my-super-function", "mysuperfunc.htm"],
-        \["my-awesome-function", "myawesomefunc.htm"]] 
+        \["my-awesome-function", "myawesomefunc.htm"]]
 
 Remember to insert a backslash at the beginning of each additional line of a
 multi-line Vim command.
@@ -679,7 +679,7 @@ Example:
     let g:slimv_template_apropos = '(apropos "%1")'
 
                                                        *g:slimv_python_version*
-Selects the python version to use. 
+Selects the python version to use.
 When exists and set to 3, the :python3 and :py3file commands are used, when
 exists and not set to 3, the :python and :pyfile commands are used, and when
 it is not defined, has('python') has('python3') determine which are used.
@@ -889,7 +889,7 @@ It is also possible to map the Ctrl-C shortcut in normal mode to perform the
 interrupt, but this may interfere with the "Copy to clipboard" function
 especially on Windows. Here is how to do it:
 
-    noremap  <silent> <C-C>      :call SlimvInterrupt()<CR> 
+    noremap  <silent> <C-C>      :call SlimvInterrupt()<CR>
 
 When a Lisp process is interrupted, we are dropped in SLDB (SLime DeBugger)
 and the list of restarts (see |swank-restarts|) and calling frame stack
@@ -957,11 +957,11 @@ Some commands have modified behaviour when used on a frame:
 
 
 -------------------------------------------------------------------------------
-STEPPER                            *step-into* *step-next* *step-out* *step-continue* 
+STEPPER                            *step-into* *step-next* *step-out* *step-continue*
 
-You can enter the stepper by either wrapping step around your code (e.g. 
+You can enter the stepper by either wrapping step around your code (e.g.
 (step (your-function arg)) or by putting (break) in your code.  If you put
-a (break) in your code, once you get into the debugger, enter step-into to 
+a (break) in your code, once you get into the debugger, enter step-into to
 enter the stepper.  The functions are:
 
 step-into: steps into the function
@@ -1239,7 +1239,7 @@ Please note that the behaviour of <CR>, <Up>, <Down> is affected by the value
 of option |g:slimv_repl_simple_eval|.
 
 The Lisp REPL can be closed by the 'Quit REPL' command (mapped to <Leader>Q
-by default). This also closes the lisp process running the SWANK server. 
+by default). This also closes the lisp process running the SWANK server.
 
 
 ===============================================================================
@@ -1487,7 +1487,7 @@ FAQ                                                                 *slimv-faq*
      - Check if the port number matches in Slimv and the SWANK server and
        :dont-close is set to 't'.
      - Verify the SWANK server command autodetected by Slimv:
-         :echo SlimvSwankCommand()         
+         :echo SlimvSwankCommand()
      - Also check the following Slimv variables in Vim, maybe they are not
        correctly autodetected and you need to override them in your .vimrc:
          :echo g:slimv_lisp

--- a/ftplugin/swank.py
+++ b/ftplugin/swank.py
@@ -1197,7 +1197,14 @@ def swank_compile_string(formvar):
     swank_rex(':compile-string-for-emacs', cmd, get_package(), 't')
 
 def swank_compile_file(name):
-    cmd = '(swank:compile-file-for-emacs ' + requote(name) + ' t)'
+    if vim.eval("exists('g:slimv_fasl_directory')") != '0':
+        fasl_directory = vim.eval('g:slimv_fasl_directory')
+        if not fasl_directory.endswith('/'):
+            fasl_directory += '/'
+        fasl_directory_arg = ' :fasl-directory ' + requote(fasl_directory)
+    else:
+        fasl_directory_arg = ''
+    cmd = '(swank:compile-file-for-emacs ' + requote(name) + ' t' + fasl_directory_arg + ')'
     swank_rex(':compile-file-for-emacs', cmd, get_package(), 't')
 
 def swank_load_file(name):

--- a/ftplugin/swank.py
+++ b/ftplugin/swank.py
@@ -10,8 +10,8 @@
 # License:      This file is placed in the public domain.
 #               No warranty, express or implied.
 #               *** ***   Use At-Your-Own-Risk!   *** ***
-# 
-############################################################################### 
+#
+###############################################################################
 
 from __future__ import print_function
 
@@ -368,7 +368,7 @@ def swank_recv(msglen, timeout):
             sock.setblocking(1)
             rec = ''
             while True:
-                # Each codepoint has at least 1 byte; so we start with the 
+                # Each codepoint has at least 1 byte; so we start with the
                 # number of bytes, and read more if needed.
                 try:
                     needed = msglen - unicode_len(rec)
@@ -545,7 +545,7 @@ def swank_parse_compile(struct):
                     snippet = unquote(location[3][1]).replace('\r', '')
                     buf = buf + snippet + '\n'
                 buf = buf + fname + ':' + pos + '\n'
-                buf = buf + '  ' + severity + ': ' + msg + '\n\n' 
+                buf = buf + '  ' + severity + ': ' + msg + '\n\n'
                 if location[2][0] == ':line':
                     lnum = pos
                     cnum = 1
@@ -802,14 +802,14 @@ def swank_listen():
 
                         elif type(params) == list and params:
                             element = ''
-                            if type(params[0]) == str: 
+                            if type(params[0]) == str:
                                 element = params[0].lower()
                             if element == ':present':
                                 # No more output from REPL, write new prompt
                                 retval = retval + new_line(retval) + unquote(params[1][0][0]) + '\n' + get_prompt()
                             elif element == ':values':
                                 retval = retval + new_line(retval)
-                                if type(params[1]) == list: 
+                                if type(params[1]) == list:
                                     retval = retval + unquote(params[1][0]) + '\n'
                                 else:
                                     retval = retval + unquote(params[1]) + '\n' + get_prompt()
@@ -1092,7 +1092,7 @@ def swank_completions(symbol):
     swank_rex(':simple-completions', cmd, 'nil', 't')
 
 def swank_fuzzy_completions(symbol):
-    cmd = '(swank:fuzzy-completions "' + symbol + '" ' + get_swank_package() + ' :limit 2000 :time-limit-in-msec 2000)' 
+    cmd = '(swank:fuzzy-completions "' + symbol + '" ' + get_swank_package() + ' :limit 2000 :time-limit-in-msec 2000)'
     swank_rex(':fuzzy-completions', cmd, 'nil', 't')
 
 def swank_undefine_function(fn):
@@ -1115,7 +1115,7 @@ def swank_return(s):
 def swank_inspect(symbol):
     global inspect_package
     cmd = '(swank:init-inspector "' + symbol + '")'
-    inspect_package = get_swank_package() 
+    inspect_package = get_swank_package()
     swank_rex(':init-inspector', cmd, inspect_package, 't')
 
 def swank_inspect_nth_part(n):


### PR DESCRIPTION
Hi, the default behavior when compiling/compile-and-loading individual files of spitting .fasl files into my source directories next to the .lisp files has been bothering me for a long time so I finally tried doing something about it, let me know your thoughts on the approach when you can. Apologies for the first commit making an uglier full diff by removing trailing whitespace, let me know if you want me to rebase it away.

Since I noticed #14 I looked for other implementations of `compile-file-for-emacs` and it seems Scheme's version is the only one that removes the options rest param used by the Lisp version for passing the fasl-directory. I was able to build a version of mit-scheme to test with, but slimv's swank did not work out of the box forcing me to set g:scheme_builtin_swank=1, which did work. I rewrote an initial version of the Python changes that just passed the path or nil to now pass the whole keyword+path or nothing. mit-scheme will still hang if this parameter is set and the Compile File command is used, but it won't break if it's missing.