### PR TITLE
Fixes to work on R7RS

### DIFF
--- a/slime/contrib/swank-mit-scheme.scm
+++ b/slime/contrib/swank-mit-scheme.scm
@@ -116,7 +116,7 @@
 
 (define (with-keyboard-interrupt-handler fun)
   (define (set-^G-handler exp)
-    (eval `(vector-set! keyboard-interrupt-vector (char->ascii #\G) ,exp)
+    (eval `(vector-set! keyboard-interrupt-vector (char->integer #\G) ,exp)
 	  (->environment '(runtime interrupt-handler))))
   (dynamic-wind
       (lambda () #f)
@@ -183,8 +183,9 @@
     ((:emacs-rex) (apply emacs-rex socket level (cdr request)))))
 
 (define (swank-package)
-  (or (name->package '(swank))
-      (name->package '(user))))
+  (if (name->package '(swank))
+      '(swank)
+      '(user)))
 
 (define *buffer-package* #f)
 (define (find-buffer-package name)


### PR DESCRIPTION
I've downloaded scheme recently (11.2 R7RS), and was surprised that it didn't work. After checking https://github.com/kovisoft/slimv/issues/117 and the code I found out that some stuff broke between R6RS to R7RS. I tested some stuff on the REPL and it seems to be working. I'm completely new to scheme, so I'm not sure if this is enough, but it ran fine as far as I tested.