### PR TITLE
fix(#56): use gitattributes to prevent CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set default behaviour to automatic
+* text=auto
+
+# Ensure ELISP files (i.e. slime.el) use LF endings on all platforms
+*.el text eol=lf


### PR DESCRIPTION
As found in issue #56, `slime.el` must use LF line endings. This PR adds a `.gitattributes` to ensure this for users that clone SLIMV with `git config core.autocrlf == true`.

Files other than ELISP (`.el`) will be converted as before.