### PR TITLE
Fixed a few problems with the hyperspec lookup that I ran into. 

### DIFF
--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -3323,11 +3323,10 @@ function! SlimvFindSymbol( word, exact, all, db, root, init )
     endif
     let lst = a:init
     let i = 0
-    let w = tolower( a:word )
     if a:exact
         while i < len( a:db )
             " Try to find an exact match
-            if a:db[i][0] == w
+            if a:db[i][0] ==? a:word
                 " No reason to check a:all here
                 return [a:db[i][0], a:root . a:db[i][1]]
             endif
@@ -3336,8 +3335,8 @@ function! SlimvFindSymbol( word, exact, all, db, root, init )
     else
         while i < len( a:db )
             " Try to find the symbol starting with the given word
-            let w2 = escape( w, '~' )
-            if match( a:db[i][0], w2 ) == 0
+            let w = escape( a:word, '~' )..'\c'
+            if match( a:db[i][0], w ) == 0
                 if a:all
                     call add( lst, a:db[i][0] )
                 else

--- a/ftplugin/slimv.vim
+++ b/ftplugin/slimv.vim
@@ -3335,7 +3335,7 @@ function! SlimvFindSymbol( word, exact, all, db, root, init )
     else
         while i < len( a:db )
             " Try to find the symbol starting with the given word
-            let w = escape( a:word, '~' )..'\c'
+            let w = escape( a:word, '~' ).'\c'
             if match( a:db[i][0], w ) == 0
                 if a:all
                     call add( lst, a:db[i][0] )


### PR DESCRIPTION
The main issue is that it was doing case sensitive searching so it never worked for format characters (e.g. ~% or ~R).  Fixed this by changing == to ==?. Second part was for the partial searches to be case insensitive so ~A and ~a both work.  Fixed this by adding \c to the end of the match string.  I used '..' which I understand is limited to version 8.1.1114 in Apr 2019.  Not sure if this will be a problem.  Now ,h works for ~a, ~A, ~%, etc.