### PR TITLE
Add ABCL support for getting the env swank port

### DIFF
--- a/slime/start-swank.lisp
+++ b/slime/start-swank.lisp
@@ -32,6 +32,7 @@
     #+SBCL (sb-unix::posix-getenv name)
     #+LISPWORKS (lispworks:environment-variable name)
     #+CCL (ccl::getenv name)
+    #+ABCL (java:jstatic "getenv" "java.lang.System" name)
     default))
 
 (swank:create-server :port (parse-integer (my-getenv "SWANK_PORT" "4005"))


### PR DESCRIPTION
This let me use the start-swank script with ABCL.
Perhaps the whole function should just be replaced with `(uiop:getenv name)` though?